### PR TITLE
Update forem GitHub URL in docs footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,7 @@ module.exports = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com',
+              href: 'https://github.com/forem/forem',
             },
           ],
         },


### PR DESCRIPTION
Update GitHub link URL from https://github.com to https://github.com/forem/forem